### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/bbengfort/stacks.png?label=ready&title=Ready)](https://waffle.io/bbengfort/stacks)
 # Bengfort Stacks [![Build Status][build_img]][build_link] #
 
 **Personal eBook library for the Bengfort Family**


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/bbengfort/stacks

This was requested by a real person (user bbengfort) on waffle.io, we're not trying to spam you.